### PR TITLE
BE-18 - Upgrade Upsource to 3.0.4

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,9 +2,10 @@ default['java']['install_flavor'] = 'oracle'
 default['java']['jdk_version'] = '8'
 default['java']['oracle']['accept_oracle_download_terms'] = true
 
-default['cookbook_upsource']['upsource']['version'] = '3.0.4291'
+default['cookbook_upsource']['upsource']['version'] = '3.0.4389'
 default['cookbook_upsource']['upsource']['install_root_dir'] = '/opt/upsource'
 default['cookbook_upsource']['upsource']['data_dir'] = '/root/.UpsourceData'
 default['cookbook_upsource']['upsource']['backup_dir'] = '/root/.UpsourceBackup'
-default['cookbook_upsource']['upsource']['download_url'] = 'https://download.jetbrains.com/upsource/upsource-3.0.4291.zip'
+default['cookbook_upsource']['upsource']['download_url'] = 'https://download.jetbrains.com/upsource/upsource-3.0.4389.zip'
 default['cookbook_upsource']['upsource']['memory_options'] = '-Xmx1g'
+default['cookbook_upsource']['upsource']['shell_script_path'] = '/opt/upsource/3.0.4389/upsource-3.0.4389/bin/upsource.sh'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'The JetBrains Upsource site.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.4'
+version          '0.0.5'
 
 recipe 'cookbook_upsource', 'The JetBrains Upsource site.'
 

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -4,16 +4,8 @@
 #
 
 # Decipher the locations
-archive_directory = Chef::Config[:file_cache_path]
-upsource_version = node['cookbook_upsource']['upsource']['version']
-install_root_dir = node['cookbook_upsource']['upsource']['install_root_dir']
-data_directory = node['cookbook_upsource']['upsource']['data_dir']
-backup_directory = node['cookbook_upsource']['upsource']['backup_dir']
 memory_options = node['cookbook_upsource']['upsource']['memory_options']
-
-# Calculate some variables
-install_dir = "#{install_root_dir}/#{upsource_version}"
-shell_script_path = "#{install_dir}/bin/upsource.sh"
+shell_script_path = node['cookbook_upsource']['upsource']['shell_script_path']
 
 # Create Upsource Service
 template '/etc/init/upsource.conf' do


### PR DESCRIPTION
Allowing the path to the shell script (used by the path) to be set, as it changes on some releases for some reason.
Upped the default values to the latest version too.

#BE-18